### PR TITLE
Add EF Core context and domain models for family archive

### DIFF
--- a/Data/FamilyArchiveContext.cs
+++ b/Data/FamilyArchiveContext.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.EntityFrameworkCore;
+using FamilyArchiveBackend.Models;
+
+namespace FamilyArchiveBackend.Data
+{
+    public class FamilyArchiveContext : DbContext
+    {
+        public FamilyArchiveContext(DbContextOptions<FamilyArchiveContext> options)
+            : base(options) { }
+
+        public DbSet<User> Users => Set<User>();
+        public DbSet<Member> Members => Set<Member>();
+        public DbSet<MemberRelationship> MemberRelationships => Set<MemberRelationship>();
+        public DbSet<MemberSpouse> MemberSpouses => Set<MemberSpouse>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            // Parent/Child composite key
+            modelBuilder.Entity<MemberRelationship>()
+                .HasKey(r => new { r.ParentId, r.ChildId });
+
+            modelBuilder.Entity<MemberRelationship>()
+                .HasOne(r => r.Parent)
+                .WithMany(m => m.Children)
+                .HasForeignKey(r => r.ParentId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            modelBuilder.Entity<MemberRelationship>()
+                .HasOne(r => r.Child)
+                .WithMany(m => m.Parents)
+                .HasForeignKey(r => r.ChildId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            // Spouse composite key
+            modelBuilder.Entity<MemberSpouse>()
+                .HasKey(s => new { s.Spouse1Id, s.Spouse2Id });
+
+            modelBuilder.Entity<MemberSpouse>()
+                .HasOne(s => s.Spouse1)
+                .WithMany(m => m.Spouses1)
+                .HasForeignKey(s => s.Spouse1Id)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            modelBuilder.Entity<MemberSpouse>()
+                .HasOne(s => s.Spouse2)
+                .WithMany(m => m.Spouses2)
+                .HasForeignKey(s => s.Spouse2Id)
+                .OnDelete(DeleteBehavior.Restrict);
+        }
+    }
+}

--- a/FamilyArchiveBackend.csproj
+++ b/FamilyArchiveBackend.csproj
@@ -7,6 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.9">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>
 

--- a/Models/Member.cs
+++ b/Models/Member.cs
@@ -1,0 +1,25 @@
+﻿namespace FamilyArchiveBackend.Models
+{
+    public class Member
+    {
+        public int Id { get; set; }
+        public string FirstName { get; set; } = string.Empty;
+        public string? MiddleName { get; set; }
+        public string? MaidenName { get; set; }
+        public string LastName { get; set; } = string.Empty;
+        public DateTime? BirthDate { get; set; }
+        public DateTime? DeathDate { get; set; }
+        public string? Gender { get; set; }
+
+        // Owner relationship
+        public int? OwnerId { get; set; }
+        public User? Owner { get; set; }
+
+        // Self-relations
+        public ICollection<MemberRelationship> Parents { get; set; } = new List<MemberRelationship>();
+        public ICollection<MemberRelationship> Children { get; set; } = new List<MemberRelationship>();
+        public ICollection<MemberSpouse> Spouses1 { get; set; } = new List<MemberSpouse>();
+        public ICollection<MemberSpouse> Spouses2 { get; set; } = new List<MemberSpouse>();
+
+    }
+}

--- a/Models/MemberRelationship.cs
+++ b/Models/MemberRelationship.cs
@@ -1,0 +1,10 @@
+﻿namespace FamilyArchiveBackend.Models
+{
+    public class MemberRelationship
+    {
+        public int ParentId { get; set; }
+        public Member Parent{ get; set; } = null!;
+        public int ChildId { get; set; }
+        public Member Child { get; set; } = null!;
+    }
+}

--- a/Models/MemberSpouse.cs
+++ b/Models/MemberSpouse.cs
@@ -1,0 +1,12 @@
+﻿namespace FamilyArchiveBackend.Models
+{
+    public class MemberSpouse
+    {
+        public int Spouse1Id { get; set; }
+        public Member Spouse1 { get; set; } = null!;
+        public int Spouse2Id { get; set; }
+        public Member Spouse2 { get; set; } = null!;
+        public DateTime? MarriedAt { get; set; }
+        public DateTime? DivorcedAt { get; set; }
+    }
+}

--- a/Models/User.cs
+++ b/Models/User.cs
@@ -1,0 +1,12 @@
+﻿namespace FamilyArchiveBackend.Models
+{
+    public class User
+    {
+        public int Id { get; set; }
+        public string UserName { get; set; } = string.Empty;
+        public string? Email { get; set; }
+        public string? Phone { get; set; }
+
+        public ICollection<Member> Members { get; set; } = new List<Member>();
+    }
+}


### PR DESCRIPTION
Introduced `FamilyArchiveContext` to define the EF Core database context, including `DbSet` properties for `User`, `Member`, `MemberRelationship`, and `MemberSpouse`. Configured composite keys and relationships for parent-child and spouse entities with `OnDelete` behavior set to `Restrict`.

Added domain models:
- `Member`: Represents family members with personal details and relationships.
- `MemberRelationship`: Represents parent-child relationships.
- `MemberSpouse`: Represents spouse relationships with optional marriage/divorce dates.
- `User`: Represents application users with associated members.

Updated `FamilyArchiveBackend.csproj` to include EF Core and PostgreSQL dependencies.